### PR TITLE
CHUI-10: Remove usages of encryptedCard iframe listener

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Id `chk-card-form` to the `iframe` containing the card form.
+
+### Changed
+- Usages of `encryptedCard` listener to use `getLastCardDigits` and `isCardValid` listeners.
+- Updated `card-form-ui` version to `v0.5.5`.
 
 ## [0.5.0] - 2020-05-18
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 - Usages of `encryptedCard` listener to use `getLastCardDigits` and `isCardValid` listeners.
-- Updated `card-form-ui` version to `v0.5.5`.
+- Updated `card-form-ui` version to `v0.6.0`.
 
 ## [0.5.0] - 2020-05-18
 ### Added

--- a/react/CreditCard.tsx
+++ b/react/CreditCard.tsx
@@ -163,7 +163,7 @@ const CreditCard: React.FC<Props> = ({
 
   const handleSubmit = async () => {
     const docIsValid = validateDoc()
-    const cardIsValid = await postRobot.send(
+    const { data: cardIsValid } = await postRobot.send(
       iframeRef.current!.contentWindow,
       'isCardValid'
     )

--- a/react/CreditCard.tsx
+++ b/react/CreditCard.tsx
@@ -41,48 +41,7 @@ interface Field {
   showError: boolean
 }
 
-interface FieldRequest {
-  value: string
-  isValid: boolean
-}
-
-interface EncryptedCardRequest {
-  encryptedCardNumber: FieldRequest
-  encryptedCardHolder: FieldRequest
-  encryptedExpiryDate: FieldRequest
-  encryptedCsc: FieldRequest
-  lastDigits: string
-}
-
-interface EncryptedCard {
-  encryptedCardNumber: string
-  encryptedCardHolder: string
-  encryptedExpiryDate: string
-  encryptedCsc: string
-  lastDigits: string
-}
-
-const getEncryptedCardRequestValues = ({
-  encryptedCardNumber,
-  encryptedCardHolder,
-  encryptedCsc,
-  encryptedExpiryDate,
-  lastDigits,
-}: EncryptedCardRequest): EncryptedCard => ({
-  encryptedCardNumber: encryptedCardNumber.value,
-  encryptedCardHolder: encryptedCardHolder.value,
-  encryptedCsc: encryptedCsc.value,
-  encryptedExpiryDate: encryptedExpiryDate.value,
-  lastDigits,
-})
-
-interface Props {
-  onCardFormCompleted: () => void
-  backToPaymentList: () => void
-  newCard: boolean
-}
-
-const IFRAME_APP_VERSION = '0.5.4'
+const IFRAME_APP_VERSION = '0.5.5'
 const PORT = 3000
 
 const iframeURLProd = `https://io.vtexpayments.com.br/card-form-ui/${IFRAME_APP_VERSION}/index.html`
@@ -101,10 +60,15 @@ const initialDoc = {
   errorMessage: '',
   showError: false,
 }
+
+interface Props {
+  onCardFormCompleted: () => void
+  onChangePaymentMethod: () => void
+}
+
 const CreditCard: React.FC<Props> = ({
   onCardFormCompleted,
-  backToPaymentList,
-  newCard,
+  onChangePaymentMethod,
 }) => {
   const { paymentSystems, setPaymentField, referenceValue } = useOrderPayment()
   const [iframeLoading, setIframeLoading] = useState(true)
@@ -115,8 +79,6 @@ const CreditCard: React.FC<Props> = ({
   ] = useState<PaymentSystem | null>(null)
 
   const [doc, setDoc] = useState<Field>(initialDoc)
-
-  const { setCardFormData } = useOrderPayment()
 
   const iframeRef = useRef<HTMLIFrameElement>(null)
   const {
@@ -156,14 +118,6 @@ const CreditCard: React.FC<Props> = ({
     setIframeLoading(false)
   }, [creditCardPaymentSystems])
 
-  const getEncryptedCard = useCallback(async (): Promise<EncryptedCardRequest | null> => {
-    const { data } = await postRobot.send(
-      iframeRef.current!.contentWindow,
-      'encryptedCard'
-    )
-    return data
-  }, [])
-
   const showCardErrors = useCallback(async () => {
     await postRobot.send(iframeRef.current!.contentWindow, 'showCardErrors')
   }, [])
@@ -172,15 +126,8 @@ const CreditCard: React.FC<Props> = ({
     if (iframeRef.current) {
       await postRobot.send(iframeRef.current.contentWindow, 'resetCardFormData')
     }
-    setCardFormData(null)
     setDoc(initialDoc)
-  }, [setCardFormData])
-
-  useEffect(() => {
-    if (newCard) {
-      resetCardFormData()
-    }
-  }, [newCard, resetCardFormData])
+  }, [])
 
   useEffect(function createPaymentSystemListener() {
     const listener = postRobot.on(
@@ -215,23 +162,16 @@ const CreditCard: React.FC<Props> = ({
   }
 
   const handleSubmit = async () => {
-    const encryptedCardRequest = await getEncryptedCard()
-    const encryptedCardIsValid =
-      encryptedCardRequest?.encryptedCardHolder.isValid &&
-      encryptedCardRequest.encryptedCardNumber.isValid &&
-      encryptedCardRequest.encryptedCsc.isValid &&
-      encryptedCardRequest.encryptedExpiryDate.isValid
-
     const docIsValid = validateDoc()
-    if (!selectedPaymentSystem || !encryptedCardIsValid || !docIsValid) {
+    const cardIsValid = await postRobot.send(
+      iframeRef.current!.contentWindow,
+      'isCardValid'
+    )
+
+    if (!selectedPaymentSystem || !cardIsValid || !docIsValid) {
       showCardErrors()
       return
     }
-    const encryptedCard = getEncryptedCardRequestValues(encryptedCardRequest!)
-
-    setCardFormData({
-      ...encryptedCard,
-    })
 
     setPaymentField({
       paymentSystem: selectedPaymentSystem.id,
@@ -252,16 +192,8 @@ const CreditCard: React.FC<Props> = ({
   }
 
   const handleCardSummaryClick = async () => {
-    const encryptedCardRequest = await getEncryptedCard()
-    if (encryptedCardRequest?.encryptedCardNumber.isValid) {
-      const encryptedCard = getEncryptedCardRequestValues(encryptedCardRequest!)
-      setCardFormData({
-        ...encryptedCard,
-      })
-    } else {
-      resetCardFormData()
-    }
-    backToPaymentList()
+    resetCardFormData()
+    onChangePaymentMethod()
   }
 
   if (isSSR) {
@@ -277,17 +209,18 @@ const CreditCard: React.FC<Props> = ({
       )}
       <div className="mb3">
         <CardSummary
-          onClick={() => handleCardSummaryClick()}
+          onClick={handleCardSummaryClick}
           type={PaymentType.CREDIT_CARD}
         />
       </div>
 
       <iframe
+        id="chk-card-form"
         className={classNames(styles.iframe, 'vw-100 w-auto-ns nh5 nh0-ns')}
         title="card-form-ui"
-        /* The scrolling attribute is set to 'no' in the iframe tag, as older versions of IE don't allow
-      this to be turned off in code and can just slightly add a bit of extra space to the bottom
-      of the content that it doesn't report when it returns the height. */
+        // The scrolling attribute is set to 'no' in the iframe tag, as older versions of IE don't allow
+        // this to be turned off in code and can just slightly add a bit of extra space to the bottom
+        // of the content that it doesn't report when it returns the height.
         scrolling="no"
         frameBorder="0"
         src={`${iframeURL}?locale=${locale}`}

--- a/react/CreditCard.tsx
+++ b/react/CreditCard.tsx
@@ -41,7 +41,7 @@ interface Field {
   showError: boolean
 }
 
-const IFRAME_APP_VERSION = '0.5.5'
+const IFRAME_APP_VERSION = '0.6.0'
 const PORT = 3000
 
 const iframeURLProd = `https://io.vtexpayments.com.br/card-form-ui/${IFRAME_APP_VERSION}/index.html`

--- a/react/CreditCard.tsx
+++ b/react/CreditCard.tsx
@@ -62,7 +62,7 @@ const initialDoc = {
 }
 
 interface Props {
-  onCardFormCompleted: () => void
+  onCardFormCompleted: (cardLastDigits: string) => void
   onChangePaymentMethod: () => void
 }
 
@@ -173,13 +173,18 @@ const CreditCard: React.FC<Props> = ({
       return
     }
 
+    const { data: cardLastDigits } = await postRobot.send(
+      iframeRef.current!.contentWindow,
+      'getCardLastDigits'
+    )
+
     setPaymentField({
       paymentSystem: selectedPaymentSystem.id,
       referenceValue,
       installments: null,
     })
 
-    onCardFormCompleted()
+    onCardFormCompleted(cardLastDigits)
   }
 
   const handleChangeDoc = (data: any) => {

--- a/react/Installments.tsx
+++ b/react/Installments.tsx
@@ -48,16 +48,16 @@ const InstallmentItem: React.FC<{
 
 interface Props {
   onInstallmentSelected: (installment: number) => void
-  backToCreditCard: () => void
+  onBackToCardForm: () => void
 }
 
 const Installments: React.FC<Props> = ({
-  backToCreditCard,
+  onBackToCardForm,
   onInstallmentSelected,
 }) => {
   const intl = useIntl()
 
-  const { installmentOptions, payment, cardFormData } = useOrderPayment()
+  const { installmentOptions, payment } = useOrderPayment()
 
   if (!payment.paymentSystem) {
     return null
@@ -76,8 +76,7 @@ const Installments: React.FC<Props> = ({
     <div>
       <div className="mb3">
         <CardSummary
-          lastDigits={cardFormData!.lastDigits}
-          onClick={backToCreditCard}
+          onClick={onBackToCardForm}
           type={PaymentType.CREDIT_CARD}
         />
       </div>

--- a/react/Installments.tsx
+++ b/react/Installments.tsx
@@ -49,11 +49,13 @@ const InstallmentItem: React.FC<{
 interface Props {
   onInstallmentSelected: (installment: number) => void
   onBackToCardForm: () => void
+  cardLastDigits: string
 }
 
 const Installments: React.FC<Props> = ({
   onBackToCardForm,
   onInstallmentSelected,
+  cardLastDigits,
 }) => {
   const intl = useIntl()
 
@@ -78,6 +80,7 @@ const Installments: React.FC<Props> = ({
         <CardSummary
           onClick={onBackToCardForm}
           type={PaymentType.CREDIT_CARD}
+          lastDigits={cardLastDigits}
         />
       </div>
 

--- a/react/Payment.tsx
+++ b/react/Payment.tsx
@@ -10,7 +10,7 @@ import { PaymentStage } from './enums/PaymentEnums'
 const REVIEW_ROUTE = '/'
 const Payment: React.FC = () => {
   const [stage, setStage] = useState<PaymentStage>(PaymentStage.PAYMENT_LIST)
-  const { cardFormData, setCardFormData, setPaymentField } = useOrderPayment()
+  const { setPaymentField } = useOrderPayment()
   const history = Router.useHistory()
 
   const onCardFormCompleted = () => {
@@ -24,20 +24,11 @@ const Payment: React.FC = () => {
     history.push(REVIEW_ROUTE)
   }
 
-  const backToCreditCard = () => {
+  const goToCardForm = () => {
     setStage(PaymentStage.CARD_FORM)
   }
 
-  const newCreditCard = () => {
-    setCardFormData(null)
-    setStage(PaymentStage.CARD_FORM)
-  }
-
-  const editCard = () => {
-    setStage(PaymentStage.CARD_FORM)
-  }
-
-  const backToPaymentList = () => {
+  const goToPaymentList = () => {
     setStage(PaymentStage.PAYMENT_LIST)
   }
 
@@ -45,17 +36,16 @@ const Payment: React.FC = () => {
     <>
       <div className={stage === PaymentStage.CARD_FORM ? '' : 'dn'}>
         <CreditCard
-          newCard={!cardFormData}
           onCardFormCompleted={onCardFormCompleted}
-          backToPaymentList={backToPaymentList}
+          onChangePaymentMethod={goToPaymentList}
         />
       </div>
       {stage === PaymentStage.PAYMENT_LIST ? (
-        <PaymentList newCreditCard={newCreditCard} editCard={editCard} />
+        <PaymentList onNewCreditCard={goToCardForm} />
       ) : stage === PaymentStage.INSTALLMENTS ? (
         <Installments
           onInstallmentSelected={onInstallmentSelected}
-          backToCreditCard={backToCreditCard}
+          onBackToCardForm={goToCardForm}
         />
       ) : null}
     </>

--- a/react/Payment.tsx
+++ b/react/Payment.tsx
@@ -8,12 +8,18 @@ import PaymentList from './PaymentList'
 import { PaymentStage } from './enums/PaymentEnums'
 
 const REVIEW_ROUTE = '/'
+
 const Payment: React.FC = () => {
   const [stage, setStage] = useState<PaymentStage>(PaymentStage.PAYMENT_LIST)
-  const { setPaymentField } = useOrderPayment()
+  const {
+    setPaymentField,
+    cardLastDigits,
+    setCardLastDigits,
+  } = useOrderPayment()
   const history = Router.useHistory()
 
-  const onCardFormCompleted = () => {
+  const onCardFormCompleted = (cardDigits: string) => {
+    setCardLastDigits(cardDigits)
     setStage(PaymentStage.INSTALLMENTS)
   }
 
@@ -46,6 +52,7 @@ const Payment: React.FC = () => {
         <Installments
           onInstallmentSelected={onInstallmentSelected}
           onBackToCardForm={goToCardForm}
+          cardLastDigits={cardLastDigits}
         />
       ) : null}
     </>

--- a/react/PaymentList.tsx
+++ b/react/PaymentList.tsx
@@ -1,5 +1,5 @@
 import React, { ReactNode } from 'react'
-import { useIntl, defineMessages, FormattedMessage } from 'react-intl'
+import { useIntl, defineMessages } from 'react-intl'
 import { GroupOption, ListGroup } from 'vtex.checkout-components'
 import { AvailableAccount } from 'vtex.checkout-graphql'
 import { PaymentFlag } from 'vtex.payment-flags'
@@ -35,34 +35,19 @@ const PaymentItem: React.FC<{
 }
 
 interface Props {
-  newCreditCard: () => void
-  editCard: () => void
+  onNewCreditCard: () => void
 }
 
-const PaymentList: React.FC<Props> = ({ newCreditCard, editCard }) => {
+const PaymentList: React.FC<Props> = ({ onNewCreditCard }) => {
   const intl = useIntl()
 
-  const { cardFormData, availableAccounts } = useOrderPayment()
+  const { availableAccounts } = useOrderPayment()
 
   return (
     <div>
       <Header>{intl.formatMessage(messages.choosePaymentMethod)}</Header>
 
       <ListGroup>
-        {cardFormData && (
-          <GroupOption onClick={editCard} caretAlign="center">
-            <PaymentItem
-              label={
-                <CardLabel
-                  label={
-                    <FormattedMessage id="store/checkout-payment.incompleteCardLabel" />
-                  }
-                  lastDigits={cardFormData.lastDigits}
-                />
-              }
-            />
-          </GroupOption>
-        )}
         {availableAccounts.map((payment: AvailableAccount) => {
           const lastDigits = payment.cardNumber.replace(/[^\d]/g, '')
           const paymentLabel = (
@@ -80,7 +65,7 @@ const PaymentList: React.FC<Props> = ({ newCreditCard, editCard }) => {
             </GroupOption>
           )
         })}
-        <GroupOption onClick={newCreditCard} caretAlign="center">
+        <GroupOption onClick={onNewCreditCard} caretAlign="center">
           <PaymentItem
             label={intl.formatMessage(messages.newCreditCardLabel)}
           />

--- a/react/PaymentSummary.tsx
+++ b/react/PaymentSummary.tsx
@@ -20,7 +20,6 @@ const PaymentSummary: React.FC = () => {
   const {
     installmentOptions,
     payment: { installments: installmentCount, paymentSystem },
-    cardFormData,
   } = useOrderPayment()
 
   const intl = useIntl()
@@ -38,7 +37,7 @@ const PaymentSummary: React.FC = () => {
 
   const formattedValue = useFormattedPrice(value / 100)
 
-  if (!selectedInstallment || !cardFormData) {
+  if (!selectedInstallment) {
     return null
   }
 
@@ -51,7 +50,7 @@ const PaymentSummary: React.FC = () => {
     <div className="c-muted-1 flex flex-column lh-copy">
       <span>
         {intl.formatMessage(messages.paymentSummaryCardMessage, {
-          value: cardFormData.lastDigits,
+          value: '1234',
         })}
       </span>
       <span>

--- a/react/PaymentSummary.tsx
+++ b/react/PaymentSummary.tsx
@@ -20,6 +20,7 @@ const PaymentSummary: React.FC = () => {
   const {
     installmentOptions,
     payment: { installments: installmentCount, paymentSystem },
+    cardLastDigits,
   } = useOrderPayment()
 
   const intl = useIntl()
@@ -50,7 +51,7 @@ const PaymentSummary: React.FC = () => {
     <div className="c-muted-1 flex flex-column lh-copy">
       <span>
         {intl.formatMessage(messages.paymentSummaryCardMessage, {
-          value: '1234',
+          value: cardLastDigits,
         })}
       </span>
       <span>

--- a/react/package.json
+++ b/react/package.json
@@ -31,9 +31,9 @@
     "vtex.document-field": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.document-field@0.1.1/public/@types/vtex.document-field",
     "vtex.formatted-price": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.formatted-price@0.4.0/public/@types/vtex.formatted-price",
     "vtex.order-manager": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-manager@0.8.4/public/@types/vtex.order-manager",
-    "vtex.order-payment": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-payment@0.4.0/public/@types/vtex.order-payment",
+    "vtex.order-payment": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-payment@0.5.0/public/@types/vtex.order-payment",
     "vtex.payment-flags": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.payment-flags@2.4.0/public/_types/react",
-    "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.103.0/public/@types/vtex.render-runtime",
+    "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.103.1/public/@types/vtex.render-runtime",
     "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.119.0/public/@types/vtex.styleguide"
   },
   "version": "0.5.0"

--- a/react/package.json
+++ b/react/package.json
@@ -25,16 +25,16 @@
     "@types/react": "^16.9.2",
     "@vtex/test-tools": "^1.1.0",
     "apollo-client": "^2.5.1",
-    "vtex.checkout-components": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-components@0.2.0/public/@types/vtex.checkout-components",
+    "vtex.checkout-components": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-components@0.3.0/public/@types/vtex.checkout-components",
     "vtex.checkout-container": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-container@0.4.0/public/@types/vtex.checkout-container",
-    "vtex.checkout-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-graphql@0.34.0/public/@types/vtex.checkout-graphql",
-    "vtex.document-field": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.document-field@0.1.0/public/@types/vtex.document-field",
+    "vtex.checkout-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-graphql@0.34.2/public/@types/vtex.checkout-graphql",
+    "vtex.document-field": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.document-field@0.1.1/public/@types/vtex.document-field",
     "vtex.formatted-price": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.formatted-price@0.4.0/public/@types/vtex.formatted-price",
     "vtex.order-manager": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-manager@0.8.4/public/@types/vtex.order-manager",
-    "vtex.order-payment": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-payment@0.3.0/public/@types/vtex.order-payment",
+    "vtex.order-payment": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-payment@0.4.0/public/@types/vtex.order-payment",
     "vtex.payment-flags": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.payment-flags@2.4.0/public/_types/react",
-    "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.100.4/public/@types/vtex.render-runtime",
-    "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.116.0/public/@types/vtex.styleguide"
+    "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.103.0/public/@types/vtex.render-runtime",
+    "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.119.0/public/@types/vtex.styleguide"
   },
   "version": "0.5.0"
 }

--- a/react/tsconfig.json
+++ b/react/tsconfig.json
@@ -9,8 +9,6 @@
     "noImplicitAny": true,
     "noImplicitReturns": true,
     "noImplicitThis": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
     "skipLibCheck": true,
     "sourceMap": true,
     "strictFunctionTypes": true,

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -4912,17 +4912,17 @@ verror@1.10.0:
   version "0.8.4"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-manager@0.8.4/public/@types/vtex.order-manager#3a4761c73364853954dd61a61d1d01260cbbf634"
 
-"vtex.order-payment@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-payment@0.4.0/public/@types/vtex.order-payment":
-  version "0.4.0"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-payment@0.4.0/public/@types/vtex.order-payment#6928fa3ccbf05a6714db424854739fd0abcd9a69"
+"vtex.order-payment@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-payment@0.5.0/public/@types/vtex.order-payment":
+  version "0.5.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-payment@0.5.0/public/@types/vtex.order-payment#8e3fd8c0c8364d16d91e0e80b251d677c9d349b9"
 
 "vtex.payment-flags@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.payment-flags@2.4.0/public/_types/react":
   version "2.4.0"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.payment-flags@2.4.0/public/_types/react#261d4a00a502f2b3b1069b5906d36b80675f04f4"
 
-"vtex.render-runtime@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.103.0/public/@types/vtex.render-runtime":
-  version "8.103.0"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.103.0/public/@types/vtex.render-runtime#55b1b260b65846e51d9cdeecfd632850f5ab4732"
+"vtex.render-runtime@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.103.1/public/@types/vtex.render-runtime":
+  version "8.103.1"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.103.1/public/@types/vtex.render-runtime#b044e7d74d38d4255f7ab3116a915180abe0cd33"
 
 "vtex.styleguide@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.119.0/public/@types/vtex.styleguide":
   version "9.119.0"

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -4888,21 +4888,21 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-"vtex.checkout-components@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-components@0.2.0/public/@types/vtex.checkout-components":
-  version "0.2.0"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-components@0.2.0/public/@types/vtex.checkout-components#b0b15ee2eccc009dca670503a047b3fda09d15c8"
+"vtex.checkout-components@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-components@0.3.0/public/@types/vtex.checkout-components":
+  version "0.3.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-components@0.3.0/public/@types/vtex.checkout-components#cbb63357d134c2ff36347bf83d20726284d8a098"
 
 "vtex.checkout-container@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-container@0.4.0/public/@types/vtex.checkout-container":
   version "0.4.0"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-container@0.4.0/public/@types/vtex.checkout-container#5510b1ebb8bc8ae565371ee70149ceee5ce1e321"
 
-"vtex.checkout-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-graphql@0.34.0/public/@types/vtex.checkout-graphql":
-  version "0.34.0"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-graphql@0.34.0/public/@types/vtex.checkout-graphql#aaed28cb41dfc29dcbae14388e665409daa9a738"
+"vtex.checkout-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-graphql@0.34.2/public/@types/vtex.checkout-graphql":
+  version "0.34.2"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-graphql@0.34.2/public/@types/vtex.checkout-graphql#44eda15d0e390604c9a29c01df7724d99f77cb97"
 
-"vtex.document-field@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.document-field@0.1.0/public/@types/vtex.document-field":
-  version "0.1.0"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.document-field@0.1.0/public/@types/vtex.document-field#dc2b3ee50609ef7abb3ec997a547e14e34d0c61a"
+"vtex.document-field@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.document-field@0.1.1/public/@types/vtex.document-field":
+  version "0.1.1"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.document-field@0.1.1/public/@types/vtex.document-field#222a1052f966f79209ee8ec998fcd43ecd7fbcce"
 
 "vtex.formatted-price@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.formatted-price@0.4.0/public/@types/vtex.formatted-price":
   version "0.4.0"
@@ -4912,21 +4912,21 @@ verror@1.10.0:
   version "0.8.4"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-manager@0.8.4/public/@types/vtex.order-manager#3a4761c73364853954dd61a61d1d01260cbbf634"
 
-"vtex.order-payment@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-payment@0.3.0/public/@types/vtex.order-payment":
-  version "0.3.0"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-payment@0.3.0/public/@types/vtex.order-payment#76837cf95bd9d4b50ca6d90fdb26305b197603a8"
+"vtex.order-payment@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-payment@0.4.0/public/@types/vtex.order-payment":
+  version "0.4.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-payment@0.4.0/public/@types/vtex.order-payment#6928fa3ccbf05a6714db424854739fd0abcd9a69"
 
 "vtex.payment-flags@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.payment-flags@2.4.0/public/_types/react":
   version "2.4.0"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.payment-flags@2.4.0/public/_types/react#261d4a00a502f2b3b1069b5906d36b80675f04f4"
 
-"vtex.render-runtime@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.100.4/public/@types/vtex.render-runtime":
-  version "8.100.4"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.100.4/public/@types/vtex.render-runtime#b94c966be2d1c3d8bc9f1caf2dd9f462d88e98d2"
+"vtex.render-runtime@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.103.0/public/@types/vtex.render-runtime":
+  version "8.103.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.103.0/public/@types/vtex.render-runtime#55b1b260b65846e51d9cdeecfd632850f5ab4732"
 
-"vtex.styleguide@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.116.0/public/@types/vtex.styleguide":
-  version "9.116.0"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.116.0/public/@types/vtex.styleguide#f17be9afb6ee66c71f2ea8d5ba81b2d18b2caa76"
+"vtex.styleguide@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.119.0/public/@types/vtex.styleguide":
+  version "9.119.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.119.0/public/@types/vtex.styleguide#e403de99f313f6ac4b065afad0079711b0992163"
 
 w3c-hr-time@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
#### What problem is this solving?

This PR removes the usages of the `encryptedCard` listener on iframe, as it will be removed on the next version of the iframe. I also updated the call sites to use the new `isCardValid` and `getCardLastDigits` listeners where appropriate.

I also added the `chk-card-form` id to the `iframe` tag, so we can communicate with it from the place order button in the review step.

[CHUI-10](https://vtex-dev.atlassian.net/browse/CHUI-10?atlOrigin=eyJpIjoiZjA2MjEwMmE0MTkwNDk1ODhhNTg3N2E1OGVjNTE4ZDciLCJwIjoiaiJ9)

#### How should this be manually tested?

[Workspace](https://placeorder--checkoutio.myvtex.com/).

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] Linked this PR to a Jira story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->