### PR TITLE
CHUI-68: Add support for boleto payment option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Support for boleto payment method.
 
 ## [0.6.0] - 2020-06-05
 ### Added

--- a/messages/en.json
+++ b/messages/en.json
@@ -11,5 +11,7 @@
   "store/checkout-payment.incompleteCardLabel": "Incomplete Card",
   "store/checkout-payment.choosePaymentMethodLabel": "Choose a payment method",
   "store/checkout-payment.paymentSummaryCardMessage": "Credit card ending with {value}",
-  "store/checkout-payment.summaryInstallments": "{installmentsMessage} {hasInterestRate, select, false {- without interest}}"
+  "store/checkout-payment.summaryInstallments": "{installmentsMessage} {hasInterestRate, select, false {- without interest}}",
+  "store/checkout-payment.boletoGenerationMessage": "Generated after purchase",
+  "store/checkout-payment.boletoNotice": "The delivery estimate is subject to payment being confirmed. This can take up to 1 business day."
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -11,5 +11,7 @@
   "store/checkout-payment.incompleteCardLabel": "Tarjeta Incompleta",
   "store/checkout-payment.choosePaymentMethodLabel": "Elija un método de pago",
   "store/checkout-payment.paymentSummaryCardMessage": "Tarjeta de crédito terminada en {value}",
-  "store/checkout-payment.summaryInstallments": "{installmentsMessage} {hasInterestRate, select, false {- sin interés}}"
+  "store/checkout-payment.summaryInstallments": "{installmentsMessage} {hasInterestRate, select, false {- sin interés}}",
+  "store/checkout-payment.boletoGenerationMessage": "Generado después de la compra",
+  "store/checkout-payment.boletoNotice": "La entrega estimada está sujeta a confirmación de pago. Esto puede demorar hasta 1 día hábil."
 }

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -11,5 +11,7 @@
   "store/checkout-payment.incompleteCardLabel": "Cartão Incompleto",
   "store/checkout-payment.choosePaymentMethodLabel": "Escolha um método de pagamento",
   "store/checkout-payment.paymentSummaryCardMessage": "Cartão de crédito terminando em {value}",
-  "store/checkout-payment.summaryInstallments": "{installmentsMessage} {hasInterestRate, select, false {- sem juros}}"
+  "store/checkout-payment.summaryInstallments": "{installmentsMessage} {hasInterestRate, select, false {- sem juros}}",
+  "store/checkout-payment.boletoGenerationMessage": "Gerado após a compra",
+  "store/checkout-payment.boletoNotice": "A estimativa de entrega está sujeita à confirmação do pagamento. Isso pode levar em até 1 dia útil."
 }

--- a/react/Payment.tsx
+++ b/react/Payment.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react'
 import { useOrderPayment } from 'vtex.order-payment/OrderPayment'
 import { Router } from 'vtex.checkout-container'
+import { PaymentSystem } from 'vtex.checkout-graphql'
 
 import CreditCard from './CreditCard'
 import Installments from './Installments'
@@ -15,6 +16,8 @@ const Payment: React.FC = () => {
     setPaymentField,
     cardLastDigits,
     setCardLastDigits,
+    value,
+    referenceValue,
   } = useOrderPayment()
   const history = Router.useHistory()
 
@@ -23,15 +26,26 @@ const Payment: React.FC = () => {
     setStage(PaymentStage.INSTALLMENTS)
   }
 
-  const onInstallmentSelected = (installment: number) => {
-    setPaymentField({
+  const onInstallmentSelected = async (installment: number) => {
+    await setPaymentField({
       installments: installment,
     })
     history.push(REVIEW_ROUTE)
   }
 
-  const goToCardForm = () => {
+  const handleNewCreditCard = () => {
     setStage(PaymentStage.CARD_FORM)
+  }
+
+  const handleBankInvoiceSelect = async (payment: PaymentSystem) => {
+    await setPaymentField({
+      paymentSystem: payment.id,
+      installments: 1,
+      installmentsInterestRate: 0,
+      value,
+      referenceValue,
+    })
+    history.push(REVIEW_ROUTE)
   }
 
   const goToPaymentList = () => {
@@ -47,11 +61,14 @@ const Payment: React.FC = () => {
         />
       </div>
       {stage === PaymentStage.PAYMENT_LIST ? (
-        <PaymentList onNewCreditCard={goToCardForm} />
+        <PaymentList
+          onNewCreditCard={handleNewCreditCard}
+          onBankInvoiceSelect={handleBankInvoiceSelect}
+        />
       ) : stage === PaymentStage.INSTALLMENTS ? (
         <Installments
           onInstallmentSelected={onInstallmentSelected}
-          onBackToCardForm={goToCardForm}
+          onBackToCardForm={handleNewCreditCard}
           cardLastDigits={cardLastDigits}
         />
       ) : null}

--- a/react/PaymentList.tsx
+++ b/react/PaymentList.tsx
@@ -1,7 +1,7 @@
 import React, { ReactNode } from 'react'
 import { useIntl, defineMessages } from 'react-intl'
 import { GroupOption, ListGroup } from 'vtex.checkout-components'
-import { AvailableAccount } from 'vtex.checkout-graphql'
+import { AvailableAccount, PaymentSystem } from 'vtex.checkout-graphql'
 import { PaymentFlag } from 'vtex.payment-flags'
 import { useOrderPayment } from 'vtex.order-payment/OrderPayment'
 
@@ -36,12 +36,20 @@ const PaymentItem: React.FC<{
 
 interface Props {
   onNewCreditCard: () => void
+  onBankInvoiceSelect: (payment: PaymentSystem) => void
 }
 
-const PaymentList: React.FC<Props> = ({ onNewCreditCard }) => {
+const PaymentList: React.FC<Props> = ({
+  onNewCreditCard,
+  onBankInvoiceSelect,
+}) => {
   const intl = useIntl()
 
-  const { availableAccounts } = useOrderPayment()
+  const { availableAccounts, paymentSystems } = useOrderPayment()
+
+  const bankInvoicePayments = paymentSystems.filter(
+    ({ groupName }) => groupName === 'bankInvoicePaymentGroup'
+  )
 
   return (
     <div>
@@ -70,6 +78,18 @@ const PaymentList: React.FC<Props> = ({ onNewCreditCard }) => {
             label={intl.formatMessage(messages.newCreditCardLabel)}
           />
         </GroupOption>
+        {bankInvoicePayments.map(paymentSystem => (
+          <GroupOption
+            caretAlign="center"
+            key={paymentSystem.id}
+            onClick={() => onBankInvoiceSelect(paymentSystem)}
+          >
+            <PaymentItem
+              label={paymentSystem.name}
+              paymentSystem={paymentSystem.id}
+            />
+          </GroupOption>
+        ))}
       </ListGroup>
     </div>
   )

--- a/react/package.json
+++ b/react/package.json
@@ -25,16 +25,16 @@
     "@types/react": "^16.9.2",
     "@vtex/test-tools": "^1.1.0",
     "apollo-client": "^2.5.1",
-    "vtex.checkout-components": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-components@0.3.0/public/@types/vtex.checkout-components",
-    "vtex.checkout-container": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-container@0.4.0/public/@types/vtex.checkout-container",
-    "vtex.checkout-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-graphql@0.34.2/public/@types/vtex.checkout-graphql",
+    "vtex.checkout-components": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-components@0.4.0/public/@types/vtex.checkout-components",
+    "vtex.checkout-container": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-container@0.4.1/public/@types/vtex.checkout-container",
+    "vtex.checkout-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-graphql@0.34.3/public/@types/vtex.checkout-graphql",
     "vtex.document-field": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.document-field@0.1.1/public/@types/vtex.document-field",
     "vtex.formatted-price": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.formatted-price@0.4.0/public/@types/vtex.formatted-price",
-    "vtex.order-manager": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-manager@0.8.4/public/@types/vtex.order-manager",
-    "vtex.order-payment": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-payment@0.5.0/public/@types/vtex.order-payment",
+    "vtex.order-manager": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-manager@0.8.5/public/@types/vtex.order-manager",
+    "vtex.order-payment": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-payment@0.6.0/public/@types/vtex.order-payment",
     "vtex.payment-flags": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.payment-flags@2.4.0/public/_types/react",
-    "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.103.1/public/@types/vtex.render-runtime",
-    "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.119.0/public/@types/vtex.styleguide"
+    "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.107.0/public/@types/vtex.render-runtime",
+    "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.120.1/public/@types/vtex.styleguide"
   },
   "version": "0.6.0"
 }

--- a/react/typings/vtex.styleguide.d.ts
+++ b/react/typings/vtex.styleguide.d.ts
@@ -11,4 +11,6 @@ declare module 'vtex.styleguide' {
   export const Input: React.FC
 
   export const IconEdit: React.FC
+
+  export const Alert: React.FC<{ type: 'success' | 'warning' | 'error' }>
 }

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -4888,17 +4888,17 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-"vtex.checkout-components@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-components@0.3.0/public/@types/vtex.checkout-components":
-  version "0.3.0"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-components@0.3.0/public/@types/vtex.checkout-components#cbb63357d134c2ff36347bf83d20726284d8a098"
-
-"vtex.checkout-container@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-container@0.4.0/public/@types/vtex.checkout-container":
+"vtex.checkout-components@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-components@0.4.0/public/@types/vtex.checkout-components":
   version "0.4.0"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-container@0.4.0/public/@types/vtex.checkout-container#5510b1ebb8bc8ae565371ee70149ceee5ce1e321"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-components@0.4.0/public/@types/vtex.checkout-components#e944338bd1d7acaee7e32dacb0ffd2bc45aa5c9b"
 
-"vtex.checkout-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-graphql@0.34.2/public/@types/vtex.checkout-graphql":
-  version "0.34.2"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-graphql@0.34.2/public/@types/vtex.checkout-graphql#44eda15d0e390604c9a29c01df7724d99f77cb97"
+"vtex.checkout-container@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-container@0.4.1/public/@types/vtex.checkout-container":
+  version "0.4.1"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-container@0.4.1/public/@types/vtex.checkout-container#b021d3d4443a1372a224dac0fabb6280b2348e2a"
+
+"vtex.checkout-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-graphql@0.34.3/public/@types/vtex.checkout-graphql":
+  version "0.34.3"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-graphql@0.34.3/public/@types/vtex.checkout-graphql#237d07d7154d65e4770ea9aa7496c63d7b822549"
 
 "vtex.document-field@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.document-field@0.1.1/public/@types/vtex.document-field":
   version "0.1.1"
@@ -4908,25 +4908,25 @@ verror@1.10.0:
   version "0.4.0"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.formatted-price@0.4.0/public/@types/vtex.formatted-price#821e3f087065704d02ee28e4f41aada3d6cb46da"
 
-"vtex.order-manager@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-manager@0.8.4/public/@types/vtex.order-manager":
-  version "0.8.4"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-manager@0.8.4/public/@types/vtex.order-manager#3a4761c73364853954dd61a61d1d01260cbbf634"
+"vtex.order-manager@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-manager@0.8.5/public/@types/vtex.order-manager":
+  version "0.8.5"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-manager@0.8.5/public/@types/vtex.order-manager#1f01414540d02e2ea7e41e73edaf431d407a9985"
 
-"vtex.order-payment@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-payment@0.5.0/public/@types/vtex.order-payment":
-  version "0.5.0"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-payment@0.5.0/public/@types/vtex.order-payment#8e3fd8c0c8364d16d91e0e80b251d677c9d349b9"
+"vtex.order-payment@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-payment@0.6.0/public/@types/vtex.order-payment":
+  version "0.6.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-payment@0.6.0/public/@types/vtex.order-payment#5203a113df53550f41449f5c43337c31a93b4fd8"
 
 "vtex.payment-flags@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.payment-flags@2.4.0/public/_types/react":
   version "2.4.0"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.payment-flags@2.4.0/public/_types/react#261d4a00a502f2b3b1069b5906d36b80675f04f4"
 
-"vtex.render-runtime@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.103.1/public/@types/vtex.render-runtime":
-  version "8.103.1"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.103.1/public/@types/vtex.render-runtime#b044e7d74d38d4255f7ab3116a915180abe0cd33"
+"vtex.render-runtime@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.107.0/public/@types/vtex.render-runtime":
+  version "8.107.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.107.0/public/@types/vtex.render-runtime#5d0085db3c560c146abe86e0c422b1e276be6ece"
 
-"vtex.styleguide@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.119.0/public/@types/vtex.styleguide":
-  version "9.119.0"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.119.0/public/@types/vtex.styleguide#e403de99f313f6ac4b065afad0079711b0992163"
+"vtex.styleguide@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.120.1/public/@types/vtex.styleguide":
+  version "9.120.1"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.120.1/public/@types/vtex.styleguide#d3c34389637b106a07b95e285b1402593768974d"
 
 w3c-hr-time@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
#### What problem is this solving?

This PR adds the support for placing the order using the "Boleto" payment option. Depends on vtex-apps/checkout#40

#### How should this be manually tested?

[Workspace](https://boleto--checkoutio.myvtex.com/cart/add?sku=289&qty=1&seller=1).

Access the above workspace and try to place the order using the "Boleto" option.

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] Linked this PR to a Jira story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->