### PR TITLE
Fix error when label isn't a string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Error when `PaymentItem#label` isn't a string.
 
 ## [0.11.1] - 2020-12-11
 ### Added

--- a/react/PaymentList.tsx
+++ b/react/PaymentList.tsx
@@ -24,12 +24,14 @@ const messages = defineMessages({
 const PaymentItem: React.FC<{
   paymentSystem?: string
   label: ReactNode
-}> = ({ paymentSystem = '', label }) => {
+  'data-testid'?: string
+}> = ({
+  paymentSystem = '',
+  label,
+  'data-testid': testId = typeof label === 'string' ? label : undefined,
+}) => {
   return (
-    <div
-      className="flex items-center c-muted-1"
-      data-testId={slugify(label as string)}
-    >
+    <div className="flex items-center c-muted-1" data-testid={slugify(testId)}>
       <div className="h2">
         <PaymentFlag paymentSystemId={paymentSystem} />
       </div>
@@ -64,11 +66,9 @@ const PaymentList: React.FC<Props> = ({
       <ListGroup>
         {availableAccounts.map((payment: AvailableAccount) => {
           const lastDigits = payment.cardNumber.replace(/[^\d]/g, '')
+          const label = intl.formatMessage(messages.creditCardLabel)
           const paymentLabel = (
-            <CardLabel
-              label={intl.formatMessage(messages.creditCardLabel)}
-              lastDigits={lastDigits}
-            />
+            <CardLabel label={label} lastDigits={lastDigits} />
           )
           return (
             <GroupOption
@@ -79,6 +79,7 @@ const PaymentList: React.FC<Props> = ({
               <PaymentItem
                 paymentSystem={payment.paymentSystem}
                 label={paymentLabel}
+                data-testid={label}
               />
             </GroupOption>
           )

--- a/react/utils/text.ts
+++ b/react/utils/text.ts
@@ -1,4 +1,4 @@
-export const slugify = (text: string) => {
+export const slugify = (text?: string) => {
   return text
     ?.toLowerCase()
     .replace(/\s+/g, '-')


### PR DESCRIPTION
#### What problem is this solving?

The `label` prop of `PaymentItem` is a `ReactNode`, meaning it can be pretty much anything, and when it isn't a string an error was being thrown in the `slugify` function.

#### How should this be manually tested?

[Workspace](https://nobatch--checkoutio.myvtex.com)

Just try to go to the payment step.

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Jira story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->
