### PR TITLE
Feat/document required

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Do not show the document field if the selected payment system does not require
 
 ## [0.12.0] - 2021-01-18
 ### Added

--- a/react/components/ExtraData.tsx
+++ b/react/components/ExtraData.tsx
@@ -74,11 +74,23 @@ const ExtraData: React.VFC<Props> = ({
   onBillingAddressChange,
   onDocumentChange,
 }) => {
-  const { cardLastDigits, payment } = useOrderPayment()
+  const { cardLastDigits, payment, paymentSystems } = useOrderPayment()
   const intl = useIntl()
   const [userDocument, setDocument] = useState<Field>(initialDocument)
 
+  const documentIsRequired = useMemo(
+    () =>
+      paymentSystems.find(
+        paymentSystem => paymentSystem.id === payment.paymentSystem
+      )?.requiresDocument ?? false,
+    [payment.paymentSystem, paymentSystems]
+  )
+
   const validateDocument = () => {
+    if (!documentIsRequired) {
+      return true
+    }
+
     if (!userDocument.value) {
       setDocument(prevDocument => ({
         ...prevDocument,
@@ -162,6 +174,7 @@ const ExtraData: React.VFC<Props> = ({
 
     onSubmit()
   }
+  const mustShowDocumentField = cardType === 'new' && documentIsRequired
 
   return (
     <div>
@@ -185,7 +198,7 @@ const ExtraData: React.VFC<Props> = ({
       </span>
 
       <form onSubmit={handleSubmit}>
-        {cardType === 'new' && (
+        {mustShowDocumentField && (
           <div className="mt6 flex items-center">
             <div className="w-100 mw-100 mw5-ns">
               <DocumentField


### PR DESCRIPTION
#### What problem is this solving?

Do not show the document field if the selected payment system does not require

#### How should this be manually tested?
Try to buy an app for `storecomponents` account.

Flow:

1. Choose EUR currency in the `Store Selector`
2. Get this [app](https://globalstore--extensions.myvtex.com/vtexromania-newsman-pixel/p?__bindingAddress=extensions.myvtex.com/). Obs: The component shows a free price but the SKU has a price. It's just for a test. 
3. Choose `storecomponents` account
4. In the checkout, fill the credit card number with a `mastercard number`. Obs: This payment system doesn’t require a document field. 
5. The document will not be required.

[Workspace](https://globalstore--extensions.myvtex.com/)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Jira story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
x | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

