### PR TITLE
Add handles to the `ExtraData` component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- CSS handles to the extra data section
+
 ## [0.13.0] - 2021-02-12
 ### Added
 - Do not show the document field if the selected payment system does not require

--- a/manifest.json
+++ b/manifest.json
@@ -27,7 +27,8 @@
     "vtex.order-payment": "0.x",
     "vtex.payment-flags": "2.x",
     "vtex.place-components": "0.x",
-    "vtex.styleguide": "9.x"
+    "vtex.styleguide": "9.x",
+    "vtex.css-handles": "1.x"
   },
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"
 }

--- a/react/Payment.tsx
+++ b/react/Payment.tsx
@@ -2,6 +2,7 @@ import React, { useState, useRef, useCallback, useEffect } from 'react'
 import { useOrderPayment } from 'vtex.order-payment/OrderPayment'
 import { Router, routes } from 'vtex.checkout-container'
 import { AvailableAccount, PaymentSystem, Address } from 'vtex.checkout-graphql'
+import { useCssHandles } from 'vtex.css-handles'
 
 import CreditCard, { CreditCardRef } from './CreditCard'
 import PaymentList from './PaymentList'
@@ -10,6 +11,8 @@ import InstallmentsModal from './components/InstallmentsModal'
 import ExtraData from './components/ExtraData'
 
 const { useHistory } = Router
+
+const CSS_HANDLES = ['creditCardContainer'] as const
 
 const Payment: React.FC = () => {
   const [cardType, setCardType] = useState<CardType>('new')
@@ -34,6 +37,8 @@ const Payment: React.FC = () => {
       history.push(routes.REVIEW)
     }
   }, [history, isFreePurchase])
+
+  const { handles } = useCssHandles(CSS_HANDLES)
 
   const handleCardFormCompleted = () => {
     setCardFormFilled(true)
@@ -112,7 +117,11 @@ const Payment: React.FC = () => {
 
   return (
     <>
-      <div className={stage === PaymentStage.CARD_FORM ? '' : 'dn'}>
+      <div
+        className={`${handles.creditCardContainer} ${
+          stage === PaymentStage.CARD_FORM ? '' : 'dn'
+        }`}
+      >
         <CreditCard
           ref={creditCardRef}
           onCardFormCompleted={handleCardFormCompleted}

--- a/react/components/ExtraData.tsx
+++ b/react/components/ExtraData.tsx
@@ -9,12 +9,25 @@ import { AddressContext } from 'vtex.address-context'
 import { Address } from 'vtex.checkout-graphql'
 import { formatAddressToString } from 'vtex.place-components'
 import { Loading } from 'vtex.render-runtime'
+import { useCssHandles } from 'vtex.css-handles'
 
 import CardSummary from '../CardSummary'
 import SelectedCardInstallments from './SelectedCardInstallments'
 import BillingAddressForm, {
   createEmptyBillingAddress,
 } from './BillingAddressForm'
+
+const CSS_HANDLES = [
+  'extraDataContainer',
+  'selectedPaymentLabel',
+  'creditCardExtraDataMessage',
+  'documentFieldSectionContainer',
+  'documentFieldContainer',
+  'billingAddressSectionContainer',
+  'billingAddressFormContainer',
+  'reviewPurchaseButtonContainer',
+  'reviewPurchaseButtonLabel',
+] as const
 
 const { AddressContextProvider, useAddressContext } = AddressContext
 
@@ -77,11 +90,12 @@ const ExtraData: React.VFC<Props> = ({
   const { cardLastDigits, payment, paymentSystems } = useOrderPayment()
   const intl = useIntl()
   const [userDocument, setDocument] = useState<Field>(initialDocument)
+  const { handles } = useCssHandles(CSS_HANDLES)
 
   const documentIsRequired = useMemo(
     () =>
       paymentSystems.find(
-        paymentSystem => paymentSystem.id === payment.paymentSystem
+        (paymentSystem) => paymentSystem.id === payment.paymentSystem
       )?.requiresDocument ?? false,
     [payment.paymentSystem, paymentSystems]
   )
@@ -92,7 +106,7 @@ const ExtraData: React.VFC<Props> = ({
     }
 
     if (!userDocument.value) {
-      setDocument(prevDocument => ({
+      setDocument((prevDocument) => ({
         ...prevDocument,
         showError: true,
         error: true,
@@ -102,7 +116,7 @@ const ExtraData: React.VFC<Props> = ({
     }
 
     if (userDocument.error) {
-      setDocument(prevDocument => ({
+      setDocument((prevDocument) => ({
         ...prevDocument,
         showError: true,
         errorMessage: intl.formatMessage(messages.invalidDigits),
@@ -130,7 +144,7 @@ const ExtraData: React.VFC<Props> = ({
   const billingAddressesOptions = useMemo(
     () =>
       (
-        orderForm.shipping.availableAddresses?.map(availableAddress => ({
+        orderForm.shipping.availableAddresses?.map((availableAddress) => ({
           label: formatAddressToString(
             availableAddress!,
             rules[availableAddress!.country as string]
@@ -156,7 +170,7 @@ const ExtraData: React.VFC<Props> = ({
     billingAddressesOptions[0].value
   )
 
-  const handleSubmit: React.FormEventHandler<HTMLFormElement> = evt => {
+  const handleSubmit: React.FormEventHandler<HTMLFormElement> = (evt) => {
     evt.preventDefault()
 
     const documentIsValid = validateDocument()
@@ -177,8 +191,8 @@ const ExtraData: React.VFC<Props> = ({
   const mustShowDocumentField = cardType === 'new' && documentIsRequired
 
   return (
-    <div>
-      <span className="dib t-heading-6 mb5">
+    <div className={handles.extraDataContainer}>
+      <span className={`${handles.selectedPaymentLabel} dib t-heading-6 mb5`}>
         {intl.formatMessage(messages.selectedPaymentLabel)}
       </span>
 
@@ -193,14 +207,20 @@ const ExtraData: React.VFC<Props> = ({
         }
       />
 
-      <span className="dib mt5 t-body lh-copy">
+      <span
+        className={`${handles.creditCardExtraDataMessage} dib mt5 t-body lh-copy`}
+      >
         {intl.formatMessage(messages.creditCardExtraDataMessage)}
       </span>
 
       <form onSubmit={handleSubmit}>
         {mustShowDocumentField && (
-          <div className="mt6 flex items-center">
-            <div className="w-100 mw-100 mw5-ns">
+          <div
+            className={`${handles.documentFieldSectionContainer} mt6 flex items-center`}
+          >
+            <div
+              className={`${handles.documentFieldContainer} w-100 mw-100 mw5-ns`}
+            >
               <DocumentField
                 label={intl.formatMessage(messages.documentLabel)}
                 documentType="cpf"
@@ -216,7 +236,7 @@ const ExtraData: React.VFC<Props> = ({
           </div>
         )}
 
-        <div className="mt6">
+        <div className={`${handles.billingAddressSectionContainer} mt6`}>
           <Dropdown
             label={intl.formatMessage(messages.billingAddressLabel)}
             options={billingAddressesOptions}
@@ -230,15 +250,15 @@ const ExtraData: React.VFC<Props> = ({
           />
 
           {selectedBillingAddressId === NEW_ADDRESS_VALUE && (
-            <div className="mt6">
+            <div className={`${handles.billingAddressFormContainer} mt6`}>
               <BillingAddressForm />
             </div>
           )}
         </div>
 
-        <div className="mt7">
+        <div className={`${handles.reviewPurchaseButtonContainer} mt7`}>
           <Button size="large" block type="submit">
-            <span className="f5">
+            <span className={`${handles.reviewPurchaseButtonLabel} f5`}>
               {intl.formatMessage(messages.reviewPurchaseLabel)}
             </span>
           </Button>

--- a/react/package.json
+++ b/react/package.json
@@ -28,17 +28,18 @@
     "apollo-client": "^2.5.1",
     "vtex.address-context": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.address-context@0.5.0/public/@types/vtex.address-context",
     "vtex.checkout-components": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-components@0.5.1/public/@types/vtex.checkout-components",
-    "vtex.checkout-container": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-container@0.6.2/public/@types/vtex.checkout-container",
-    "vtex.checkout-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-graphql@0.55.1/public/@types/vtex.checkout-graphql",
-    "vtex.checkout-shipping": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-shipping@0.6.5/public/@types/vtex.checkout-shipping",
+    "vtex.checkout-container": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-container@0.7.0/public/@types/vtex.checkout-container",
+    "vtex.checkout-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-graphql@0.56.1/public/@types/vtex.checkout-graphql",
+    "vtex.checkout-shipping": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-shipping@0.6.6/public/@types/vtex.checkout-shipping",
+    "vtex.css-handles": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.css-handles@1.0.0/public/@types/vtex.css-handles",
     "vtex.document-field": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.document-field@0.1.1/public/@types/vtex.document-field",
     "vtex.formatted-price": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.formatted-price@0.4.0/public/@types/vtex.formatted-price",
     "vtex.order-manager": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-manager@0.9.0/public/@types/vtex.order-manager",
     "vtex.order-payment": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-payment@0.8.0/public/@types/vtex.order-payment",
     "vtex.payment-flags": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.payment-flags@2.5.1/public/@types/vtex.payment-flags",
-    "vtex.place-components": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.place-components@0.13.9/public/@types/vtex.place-components",
-    "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.126.6/public/@types/vtex.render-runtime",
-    "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.134.1/public/@types/vtex.styleguide"
+    "vtex.place-components": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.place-components@0.14.0/public/@types/vtex.place-components",
+    "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.126.11/public/@types/vtex.render-runtime",
+    "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.135.1/public/@types/vtex.styleguide"
   },
   "version": "0.13.0"
 }

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -5378,17 +5378,21 @@ verror@1.10.0:
   version "0.5.1"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-components@0.5.1/public/@types/vtex.checkout-components#77d654aea75319f3024612fe7b263777b116105f"
 
-"vtex.checkout-container@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-container@0.6.2/public/@types/vtex.checkout-container":
-  version "0.6.2"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-container@0.6.2/public/@types/vtex.checkout-container#a3862cecfeaf1af70e26f70e24a51224297e1138"
+"vtex.checkout-container@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-container@0.7.0/public/@types/vtex.checkout-container":
+  version "0.7.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-container@0.7.0/public/@types/vtex.checkout-container#4c06bc1357567e7dd6cff1f18c1ac15c64fd72c9"
 
-"vtex.checkout-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-graphql@0.55.1/public/@types/vtex.checkout-graphql":
-  version "0.55.1"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-graphql@0.55.1/public/@types/vtex.checkout-graphql#a9f282941d74fffac3d3d877d92313dd755de07f"
+"vtex.checkout-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-graphql@0.56.1/public/@types/vtex.checkout-graphql":
+  version "0.56.1"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-graphql@0.56.1/public/@types/vtex.checkout-graphql#c1153ec5faf232f92abfe495f867019bfb7d510f"
 
-"vtex.checkout-shipping@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-shipping@0.6.5/public/@types/vtex.checkout-shipping":
-  version "0.6.5"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-shipping@0.6.5/public/@types/vtex.checkout-shipping#b7ea02ac0236010424972f1408e031fa8302ae09"
+"vtex.checkout-shipping@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-shipping@0.6.6/public/@types/vtex.checkout-shipping":
+  version "0.6.6"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-shipping@0.6.6/public/@types/vtex.checkout-shipping#c71713765bf87c50bb64016738450171a6e91c12"
+
+"vtex.css-handles@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.css-handles@1.0.0/public/@types/vtex.css-handles":
+  version "1.0.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.css-handles@1.0.0/public/@types/vtex.css-handles#336b23ef3a9bcb2b809529ba736783acd405d081"
 
 "vtex.document-field@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.document-field@0.1.1/public/@types/vtex.document-field":
   version "0.1.1"
@@ -5410,17 +5414,17 @@ verror@1.10.0:
   version "2.5.1"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.payment-flags@2.5.1/public/@types/vtex.payment-flags#27bdf241ffd829047384f6d2114e24fb581c5510"
 
-"vtex.place-components@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.place-components@0.13.9/public/@types/vtex.place-components":
-  version "0.13.9"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.place-components@0.13.9/public/@types/vtex.place-components#8009d4b07e7889824d1414dc376952759103eea5"
+"vtex.place-components@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.place-components@0.14.0/public/@types/vtex.place-components":
+  version "0.14.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.place-components@0.14.0/public/@types/vtex.place-components#12c30beed1f4457c748684b22348338bc3164a11"
 
-"vtex.render-runtime@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.126.6/public/@types/vtex.render-runtime":
-  version "8.126.6"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.126.6/public/@types/vtex.render-runtime#78ae3da048ec823ab104425aef14e66165ed1303"
+"vtex.render-runtime@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.126.11/public/@types/vtex.render-runtime":
+  version "8.126.11"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.126.11/public/@types/vtex.render-runtime#aceb734766093b56954ec19a074574b4c2c95242"
 
-"vtex.styleguide@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.134.1/public/@types/vtex.styleguide":
-  version "9.134.1"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.134.1/public/@types/vtex.styleguide#7210ed4908f4e6482d2499d71c4cfcc21e3dfd6a"
+"vtex.styleguide@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.135.1/public/@types/vtex.styleguide":
+  version "9.135.1"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.135.1/public/@types/vtex.styleguide#ed8d203eff74ed072b6e2f6ddb66d0c92b797ade"
 
 w3c-hr-time@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
#### What problem is this solving?

Adds customization possibilities to the `ExtraData` section

#### How should this be manually tested?

1. Visit this linked [workspace](https://newartur--extensions.myvtex.com/vtex-sms-provider/p)
2. Click `Get App`
3. Provide a store name, e.g. `storecomponents`
4. When the login flow is done, you'll be able to edit payment options. Choose Credit Card
5. Notice that when extra data information is required, no billing address inputs are displayed

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Jira story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

Before:

![image](https://user-images.githubusercontent.com/3827456/108277321-016e5200-7158-11eb-8c67-29fde3faf9cd.png)

After:

![image](https://user-images.githubusercontent.com/3827456/108277445-2a8ee280-7158-11eb-8585-8dc6d9bf1ff2.png)

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

In this customization, the following customization is active:

`vtex.checkout-step-group.css`
```css
.billingAddressSectionContainer {
  display: none;
}
```
