### PR TITLE
Add parameter to opt for new billing address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- `billingAddressType` parameter to allow control of Billing Addres input
+
 ## [0.13.1] - 2021-02-23
 ### Fixed
 - Validation on billing address form.

--- a/react/Payment.tsx
+++ b/react/Payment.tsx
@@ -11,7 +11,11 @@ import ExtraData from './components/ExtraData'
 
 const { useHistory } = Router
 
-const Payment: React.FC = () => {
+interface Props {
+  billingAddressType?: BillingAddressType
+}
+
+const Payment: React.FC<Props> = ({ billingAddressType = 'saved' }) => {
   const [cardType, setCardType] = useState<CardType>('new')
   const {
     setPaymentField,
@@ -136,6 +140,7 @@ const Payment: React.FC = () => {
           onChangeInstallments={() => setInstallmentsModalOpen(true)}
           onBillingAddressChange={handleBillingAddressChange}
           onDocumentChange={handleDocumentChange}
+          billingAddressType={billingAddressType}
         />
       ) : null}
       <InstallmentsModal

--- a/react/typings/global.d.ts
+++ b/react/typings/global.d.ts
@@ -15,4 +15,6 @@ declare global {
   }
 
   type CardType = 'new' | 'saved'
+
+  type BillingAddressType = 'new' | 'saved'
 }


### PR DESCRIPTION
#### What problem is this solving?

Adds an optional parameter to the `Payment` component, that, when used, can force the input of the billing address. This follows the idea described [in this discussion](https://vtex.slack.com/archives/CAGU9S7B9/p1610998408001200)

#### How should this be manually tested?

1. Visit this linked [workspace](https://newartur--extensions.myvtex.com/vtex-sms-provider/p)
2. Click `Get App`
3. Provide a store name, e.g. `storecomponents`
4. When the login flow is done, you'll be able to edit payment options. Choose Credit Card
5. Notice that when extra data information is required, the billing address is required

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Jira story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

How this looks like:
![image](https://user-images.githubusercontent.com/3827456/108282402-4eeebd00-7160-11eb-8f3b-2b2d85b1a211.png)

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️| New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
