### PR TITLE
Fix validation in billing address form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Validation on billing address form.
 
 ## [0.12.0] - 2021-01-18
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -20,7 +20,6 @@
     "vtex.checkout-components": "0.x",
     "vtex.checkout-container": "0.x",
     "vtex.checkout-graphql": "0.x",
-    "vtex.checkout-shipping": "0.x",
     "vtex.document-field": "0.x",
     "vtex.formatted-price": "0.x",
     "vtex.order-manager": "0.x",

--- a/messages/en.json
+++ b/messages/en.json
@@ -25,5 +25,6 @@
   "store/checkout-payment.billingAddressLabel": "Billing address",
   "store/checkout-payment.newAddressLabel": "+ New address",
   "store/checkout-payment.cardFormTitle": "Container for credit card form",
-  "store/checkout-payment.freePurchase": "Your purchase is free"
+  "store/checkout-payment.freePurchase": "Your purchase is free",
+  "store/checkout-payment.informBillingAddress": "Please inform your billing address"
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -25,5 +25,6 @@
   "store/checkout-payment.billingAddressLabel": "Dirección de facturación",
   "store/checkout-payment.newAddressLabel": "+ Nueva dirección",
   "store/checkout-payment.cardFormTitle": "Contenedor para formulario de tarjeta de crédito",
-  "store/checkout-payment.freePurchase": "Tu compra es gratis"
+  "store/checkout-payment.freePurchase": "Tu compra es gratis",
+  "store/checkout-payment.informBillingAddress": "Ingrese su dirección de facturación"
 }

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -25,5 +25,6 @@
   "store/checkout-payment.billingAddressLabel": "Endereço de fatura",
   "store/checkout-payment.newAddressLabel": "+ Novo endereço",
   "store/checkout-payment.cardFormTitle": "Contêiner para o formulário de cartão de crédito",
-  "store/checkout-payment.freePurchase": "Sua compra é grátis"
+  "store/checkout-payment.freePurchase": "Sua compra é grátis",
+  "store/checkout-payment.informBillingAddress": "Por favor informe o endereço de faturamento"
 }

--- a/react/components/BillingAddressForm.tsx
+++ b/react/components/BillingAddressForm.tsx
@@ -1,9 +1,11 @@
 import React from 'react'
-import { ShippingHeader } from 'vtex.checkout-shipping'
-import { LocationInput, AddressForm } from 'vtex.place-components'
-import { AddressContext, Utils } from 'vtex.address-context'
-
-const { useAddressContext } = AddressContext
+import {
+  LocationInput,
+  AddressForm,
+  useAddressForm,
+} from 'vtex.place-components'
+import { Utils } from 'vtex.address-context'
+import { FormattedMessage } from 'react-intl'
 
 export const createEmptyBillingAddress = () => {
   const { receiverName, ...address } = Utils.createEmptyAddress(true)
@@ -11,19 +13,22 @@ export const createEmptyBillingAddress = () => {
   return address
 }
 
-const BillingAddressForm: React.VFC = () => {
-  const { invalidFields, setAddress } = useAddressContext()
-
+const BillingAddressForm: React.VFC<{
+  form: ReturnType<typeof useAddressForm>
+}> = ({ form }) => {
   return (
     <>
-      {invalidFields.includes('postalCode') ? (
+      {form.invalidFields.includes('postalCode') ? (
         <>
-          <ShippingHeader />
-          <LocationInput />
+          <p className="t-body mt0 mb6">
+            <FormattedMessage id="store/checkout-payment.informBillingAddress" />
+          </p>
+          <LocationInput onSuccess={address => form.setAddress(address)} />
         </>
       ) : (
         <AddressForm
-          onResetAddress={() => setAddress(createEmptyBillingAddress())}
+          onResetAddress={() => form.setAddress(createEmptyBillingAddress())}
+          form={form}
         />
       )}
     </>

--- a/react/components/ExtraData.tsx
+++ b/react/components/ExtraData.tsx
@@ -4,10 +4,9 @@ import { defineMessages, useIntl } from 'react-intl'
 import { Button, Dropdown } from 'vtex.styleguide'
 import { DocumentField } from 'vtex.document-field'
 import { useOrderForm } from 'vtex.order-manager/OrderForm'
-import { useAddressRules } from 'vtex.checkout-shipping'
-import { AddressContext } from 'vtex.address-context'
+import { AddressContext, useAddressRules } from 'vtex.address-context'
 import { Address } from 'vtex.checkout-graphql'
-import { formatAddressToString } from 'vtex.place-components'
+import { formatAddressToString, useAddressForm } from 'vtex.place-components'
 import { Loading } from 'vtex.render-runtime'
 
 import CardSummary from '../CardSummary'
@@ -113,7 +112,7 @@ const ExtraData: React.VFC<Props> = ({
   }
 
   const { orderForm } = useOrderForm()
-  const { address, rules, invalidFields } = useAddressContext()
+  const { rules } = useAddressContext()
 
   const billingAddressesOptions = useMemo(
     () =>
@@ -134,29 +133,40 @@ const ExtraData: React.VFC<Props> = ({
     [orderForm.shipping.availableAddresses, intl, rules]
   )
 
-  useEffect(() => {
-    const { __typename, ...addressWithoutTypename } = address
-
-    onBillingAddressChange(addressWithoutTypename)
-  }, [address, onBillingAddressChange])
-
   const [selectedBillingAddressId, setSelectedBillingAddressId] = useState(
     billingAddressesOptions[0].value
   )
+
+  const billingForm = useAddressForm()
+
+  useEffect(() => {
+    const { __typename, ...addressWithoutTypename } = billingForm.address
+
+    onBillingAddressChange(addressWithoutTypename)
+  }, [billingForm.address, onBillingAddressChange])
 
   const handleSubmit: React.FormEventHandler<HTMLFormElement> = evt => {
     evt.preventDefault()
 
     const documentIsValid = validateDocument()
 
+    let shouldSubmit = true
+
     if (cardType === 'new' && !documentIsValid) {
-      return
+      shouldSubmit = false
     }
 
     if (
       selectedBillingAddressId === NEW_ADDRESS_VALUE &&
-      (invalidFields.length > 1 || !invalidFields.includes('receiverName'))
+      !billingForm.isValid
     ) {
+      billingForm.invalidFields.forEach(field => {
+        billingForm.onFieldBlur(field)
+      })
+      shouldSubmit = false
+    }
+
+    if (!shouldSubmit) {
       return
     }
 
@@ -218,7 +228,7 @@ const ExtraData: React.VFC<Props> = ({
 
           {selectedBillingAddressId === NEW_ADDRESS_VALUE && (
             <div className="mt6">
-              <BillingAddressForm />
+              <BillingAddressForm form={billingForm} />
             </div>
           )}
         </div>

--- a/react/package.json
+++ b/react/package.json
@@ -26,19 +26,18 @@
     "@types/react-dom": "^16.9.9",
     "@vtex/test-tools": "^3.3.2",
     "apollo-client": "^2.5.1",
-    "vtex.address-context": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.address-context@0.5.0/public/@types/vtex.address-context",
+    "vtex.address-context": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.address-context@0.6.2/public/@types/vtex.address-context",
     "vtex.checkout-components": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-components@0.5.1/public/@types/vtex.checkout-components",
-    "vtex.checkout-container": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-container@0.6.2/public/@types/vtex.checkout-container",
-    "vtex.checkout-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-graphql@0.55.1/public/@types/vtex.checkout-graphql",
-    "vtex.checkout-shipping": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-shipping@0.6.5/public/@types/vtex.checkout-shipping",
+    "vtex.checkout-container": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-container@0.7.0/public/@types/vtex.checkout-container",
+    "vtex.checkout-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-graphql@0.56.1/public/@types/vtex.checkout-graphql",
     "vtex.document-field": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.document-field@0.1.1/public/@types/vtex.document-field",
     "vtex.formatted-price": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.formatted-price@0.4.0/public/@types/vtex.formatted-price",
     "vtex.order-manager": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-manager@0.9.0/public/@types/vtex.order-manager",
     "vtex.order-payment": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-payment@0.8.0/public/@types/vtex.order-payment",
     "vtex.payment-flags": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.payment-flags@2.5.1/public/@types/vtex.payment-flags",
-    "vtex.place-components": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.place-components@0.13.9/public/@types/vtex.place-components",
-    "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.126.6/public/@types/vtex.render-runtime",
-    "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.134.1/public/@types/vtex.styleguide"
+    "vtex.place-components": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.place-components@0.14.0/public/@types/vtex.place-components",
+    "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.126.11/public/@types/vtex.render-runtime",
+    "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.135.3/public/@types/vtex.styleguide"
   },
   "version": "0.12.0"
 }

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -5370,25 +5370,21 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-"vtex.address-context@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.address-context@0.5.0/public/@types/vtex.address-context":
-  version "0.5.0"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.address-context@0.5.0/public/@types/vtex.address-context#3f984bc73fba901d1c7dbdcebea8d29c7bc450e9"
+"vtex.address-context@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.address-context@0.6.2/public/@types/vtex.address-context":
+  version "0.6.2"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.address-context@0.6.2/public/@types/vtex.address-context#f204028dd8a15f4ea0bfe28126684fec34758774"
 
 "vtex.checkout-components@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-components@0.5.1/public/@types/vtex.checkout-components":
   version "0.5.1"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-components@0.5.1/public/@types/vtex.checkout-components#77d654aea75319f3024612fe7b263777b116105f"
 
-"vtex.checkout-container@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-container@0.6.2/public/@types/vtex.checkout-container":
-  version "0.6.2"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-container@0.6.2/public/@types/vtex.checkout-container#a3862cecfeaf1af70e26f70e24a51224297e1138"
+"vtex.checkout-container@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-container@0.7.0/public/@types/vtex.checkout-container":
+  version "0.7.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-container@0.7.0/public/@types/vtex.checkout-container#4c06bc1357567e7dd6cff1f18c1ac15c64fd72c9"
 
-"vtex.checkout-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-graphql@0.55.1/public/@types/vtex.checkout-graphql":
-  version "0.55.1"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-graphql@0.55.1/public/@types/vtex.checkout-graphql#a9f282941d74fffac3d3d877d92313dd755de07f"
-
-"vtex.checkout-shipping@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-shipping@0.6.5/public/@types/vtex.checkout-shipping":
-  version "0.6.5"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-shipping@0.6.5/public/@types/vtex.checkout-shipping#b7ea02ac0236010424972f1408e031fa8302ae09"
+"vtex.checkout-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-graphql@0.56.1/public/@types/vtex.checkout-graphql":
+  version "0.56.1"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-graphql@0.56.1/public/@types/vtex.checkout-graphql#c1153ec5faf232f92abfe495f867019bfb7d510f"
 
 "vtex.document-field@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.document-field@0.1.1/public/@types/vtex.document-field":
   version "0.1.1"
@@ -5410,17 +5406,17 @@ verror@1.10.0:
   version "2.5.1"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.payment-flags@2.5.1/public/@types/vtex.payment-flags#27bdf241ffd829047384f6d2114e24fb581c5510"
 
-"vtex.place-components@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.place-components@0.13.9/public/@types/vtex.place-components":
-  version "0.13.9"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.place-components@0.13.9/public/@types/vtex.place-components#8009d4b07e7889824d1414dc376952759103eea5"
+"vtex.place-components@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.place-components@0.14.0/public/@types/vtex.place-components":
+  version "0.14.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.place-components@0.14.0/public/@types/vtex.place-components#12c30beed1f4457c748684b22348338bc3164a11"
 
-"vtex.render-runtime@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.126.6/public/@types/vtex.render-runtime":
-  version "8.126.6"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.126.6/public/@types/vtex.render-runtime#78ae3da048ec823ab104425aef14e66165ed1303"
+"vtex.render-runtime@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.126.11/public/@types/vtex.render-runtime":
+  version "8.126.11"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.126.11/public/@types/vtex.render-runtime#aceb734766093b56954ec19a074574b4c2c95242"
 
-"vtex.styleguide@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.134.1/public/@types/vtex.styleguide":
-  version "9.134.1"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.134.1/public/@types/vtex.styleguide#7210ed4908f4e6482d2499d71c4cfcc21e3dfd6a"
+"vtex.styleguide@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.135.3/public/@types/vtex.styleguide":
+  version "9.135.3"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.135.3/public/@types/vtex.styleguide#744a8674d69a56594de969da36b263f94c9de66f"
 
 w3c-hr-time@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
#### What problem is this solving?

Similar to what was done in address step of Checkout, we want to warn the user of invalid fields when they try to proceed with an invalid form. This PR fixes this behavior by using the new `useAddressForm` hook which gives more granular control over address and error states inside the form.

#### How should this be manually tested?

[Workspace](https://microbiano--checkoutio.myvtex.com/cart/add?sku=289).

1. To see the desired behavior, proceed to the payment step in checkout and select a new credit card.
2. Then, select to insert a new billing address and use the postal code `22250-040`.
3. When the address form opens up, try to click the submit button.
4. All invalid fields should have an error message beneath of them.
5. Fix the errors and you should be able to proceed.

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Jira story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->
