### PR TITLE
Add handles to the `ExtraData` and `PaymentList` components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- CSS handles to the extra data section
+
 ## [0.13.1] - 2021-02-23
 ### Fixed
 - Validation on billing address form.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 First of all (even before the block's name), its README.md should contain the following sentence at the very beginning:
 
-`=â Use this project, [contribute](https://github.com/{OrganizationName/{AppName}) to it or open issues to help evolve it using [Store Discussion](https://github.com/vtex-apps/store-discussion).`
+`=ï¿½ Use this project, [contribute](https://github.com/{OrganizationName/{AppName}) to it or open issues to help evolve it using [Store Discussion](https://github.com/vtex-apps/store-discussion).`
 
 # BLOCK NAME
 
@@ -38,13 +38,21 @@ The first thing that should be present in this section is the sentence below, sh
 Thereafter, you should add a single column table with the available CSS handles for that block:
 
 | CSS Handles |
-| ----------- | 
-| `XXXXX` | 
-| `XXXXX` | 
-| `XXXXX` | 
-| `XXXXX` | 
-| `XXXXX` |
-
+| ----------- |
+| `paymentListContainer` |
+| `savedCreditCardOption` |
+| `newCreditCardOption` |
+| `bankInvoiceOption` |
+| `creditCardContainer` |
+| `extraDataContainer` |
+| `selectedPaymentLabel` |
+| `creditCardExtraDataMessage` |
+| `documentFieldSectionContainer` |
+| `documentFieldContainer` |
+| `billingAddressSectionContainer` |
+| `billingAddressFormContainer` |
+| `reviewPurchaseButtonContainer` |
+| `reviewPurchaseButtonLabel` |
 
 If there are none, add the following sentence instead:
 

--- a/manifest.json
+++ b/manifest.json
@@ -26,7 +26,8 @@
     "vtex.order-payment": "0.x",
     "vtex.payment-flags": "2.x",
     "vtex.place-components": "0.x",
-    "vtex.styleguide": "9.x"
+    "vtex.styleguide": "9.x",
+    "vtex.css-handles": "1.x"
   },
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"
 }

--- a/react/Payment.tsx
+++ b/react/Payment.tsx
@@ -2,6 +2,7 @@ import React, { useState, useRef, useCallback, useEffect } from 'react'
 import { useOrderPayment } from 'vtex.order-payment/OrderPayment'
 import { Router, routes } from 'vtex.checkout-container'
 import { AvailableAccount, PaymentSystem, Address } from 'vtex.checkout-graphql'
+import { useCssHandles } from 'vtex.css-handles'
 
 import CreditCard, { CreditCardRef } from './CreditCard'
 import PaymentList from './PaymentList'
@@ -10,6 +11,8 @@ import InstallmentsModal from './components/InstallmentsModal'
 import ExtraData from './components/ExtraData'
 
 const { useHistory } = Router
+
+const CSS_HANDLES = ['creditCardContainer'] as const
 
 const Payment: React.FC = () => {
   const [cardType, setCardType] = useState<CardType>('new')
@@ -34,6 +37,8 @@ const Payment: React.FC = () => {
       history.push(routes.REVIEW)
     }
   }, [history, isFreePurchase])
+
+  const { handles } = useCssHandles(CSS_HANDLES)
 
   const handleCardFormCompleted = () => {
     setCardFormFilled(true)
@@ -112,7 +117,11 @@ const Payment: React.FC = () => {
 
   return (
     <>
-      <div className={stage === PaymentStage.CARD_FORM ? '' : 'dn'}>
+      <div
+        className={`${handles.creditCardContainer} ${
+          stage === PaymentStage.CARD_FORM ? '' : 'dn'
+        }`}
+      >
         <CreditCard
           ref={creditCardRef}
           onCardFormCompleted={handleCardFormCompleted}

--- a/react/PaymentList.tsx
+++ b/react/PaymentList.tsx
@@ -1,6 +1,7 @@
 import React, { ReactNode } from 'react'
 import { useIntl, defineMessages } from 'react-intl'
 import { GroupOption, ListGroup } from 'vtex.checkout-components'
+import { useCssHandles } from 'vtex.css-handles'
 import { AvailableAccount, PaymentSystem } from 'vtex.checkout-graphql'
 import { PaymentFlag } from 'vtex.payment-flags'
 import { useOrderPayment } from 'vtex.order-payment/OrderPayment'
@@ -8,6 +9,13 @@ import { useOrderPayment } from 'vtex.order-payment/OrderPayment'
 import Header from './components/Header'
 import CardLabel from './components/CardLabel'
 import { slugify } from './utils/text'
+
+const CSS_HANDLES = [
+  'paymentListContainer',
+  'savedCreditCardOption',
+  'newCreditCardOption',
+  'bankInvoiceOption',
+] as const
 
 const messages = defineMessages({
   choosePaymentMethod: {
@@ -55,12 +63,14 @@ const PaymentList: React.FC<Props> = ({
 
   const { availableAccounts, paymentSystems } = useOrderPayment()
 
+  const { handles } = useCssHandles(CSS_HANDLES)
+
   const bankInvoicePayments = paymentSystems.filter(
     ({ groupName }) => groupName === 'bankInvoicePaymentGroup'
   )
 
   return (
-    <div>
+    <div className={handles.paymentListContainer}>
       <Header>{intl.formatMessage(messages.choosePaymentMethod)}</Header>
 
       <ListGroup>
@@ -75,6 +85,7 @@ const PaymentList: React.FC<Props> = ({
               onClick={() => onSavedCreditCard(payment)}
               key={payment.accountId}
               caretAlign="center"
+              className={handles.savedCreditCardOption}
             >
               <PaymentItem
                 paymentSystem={payment.paymentSystem}
@@ -84,7 +95,11 @@ const PaymentList: React.FC<Props> = ({
             </GroupOption>
           )
         })}
-        <GroupOption onClick={onNewCreditCard} caretAlign="center">
+        <GroupOption
+          onClick={onNewCreditCard}
+          caretAlign="center"
+          className={handles.newCreditCardOption}
+        >
           <PaymentItem
             label={intl.formatMessage(messages.newCreditCardLabel)}
           />
@@ -94,6 +109,7 @@ const PaymentList: React.FC<Props> = ({
             caretAlign="center"
             key={paymentSystem.id}
             onClick={() => onBankInvoiceSelect(paymentSystem)}
+            className={handles.bankInvoiceOption}
           >
             <PaymentItem
               label={paymentSystem.name}

--- a/react/components/ExtraData.tsx
+++ b/react/components/ExtraData.tsx
@@ -8,12 +8,25 @@ import { AddressContext, useAddressRules } from 'vtex.address-context'
 import { Address } from 'vtex.checkout-graphql'
 import { formatAddressToString, useAddressForm } from 'vtex.place-components'
 import { Loading } from 'vtex.render-runtime'
+import { useCssHandles } from 'vtex.css-handles'
 
 import CardSummary from '../CardSummary'
 import SelectedCardInstallments from './SelectedCardInstallments'
 import BillingAddressForm, {
   createEmptyBillingAddress,
 } from './BillingAddressForm'
+
+const CSS_HANDLES = [
+  'extraDataContainer',
+  'selectedPaymentLabel',
+  'creditCardExtraDataMessage',
+  'documentFieldSectionContainer',
+  'documentFieldContainer',
+  'billingAddressSectionContainer',
+  'billingAddressFormContainer',
+  'reviewPurchaseButtonContainer',
+  'reviewPurchaseButtonLabel',
+] as const
 
 const { AddressContextProvider, useAddressContext } = AddressContext
 
@@ -76,11 +89,12 @@ const ExtraData: React.VFC<Props> = ({
   const { cardLastDigits, payment, paymentSystems } = useOrderPayment()
   const intl = useIntl()
   const [userDocument, setDocument] = useState<Field>(initialDocument)
+  const { handles } = useCssHandles(CSS_HANDLES)
 
   const documentIsRequired = useMemo(
     () =>
       paymentSystems.find(
-        paymentSystem => paymentSystem.id === payment.paymentSystem
+        (paymentSystem) => paymentSystem.id === payment.paymentSystem
       )?.requiresDocument ?? false,
     [payment.paymentSystem, paymentSystems]
   )
@@ -91,7 +105,7 @@ const ExtraData: React.VFC<Props> = ({
     }
 
     if (!userDocument.value) {
-      setDocument(prevDocument => ({
+      setDocument((prevDocument) => ({
         ...prevDocument,
         showError: true,
         error: true,
@@ -101,7 +115,7 @@ const ExtraData: React.VFC<Props> = ({
     }
 
     if (userDocument.error) {
-      setDocument(prevDocument => ({
+      setDocument((prevDocument) => ({
         ...prevDocument,
         showError: true,
         errorMessage: intl.formatMessage(messages.invalidDigits),
@@ -129,7 +143,7 @@ const ExtraData: React.VFC<Props> = ({
   const billingAddressesOptions = useMemo(
     () =>
       (
-        orderForm.shipping.availableAddresses?.map(availableAddress => ({
+        orderForm.shipping.availableAddresses?.map((availableAddress) => ({
           label: formatAddressToString(
             availableAddress!,
             rules[availableAddress!.country as string]
@@ -157,7 +171,7 @@ const ExtraData: React.VFC<Props> = ({
     onBillingAddressChange(addressWithoutTypename)
   }, [billingForm.address, onBillingAddressChange])
 
-  const handleSubmit: React.FormEventHandler<HTMLFormElement> = evt => {
+  const handleSubmit: React.FormEventHandler<HTMLFormElement> = (evt) => {
     evt.preventDefault()
 
     const documentIsValid = validateDocument()
@@ -172,7 +186,7 @@ const ExtraData: React.VFC<Props> = ({
       selectedBillingAddressId === NEW_ADDRESS_VALUE &&
       !billingForm.isValid
     ) {
-      billingForm.invalidFields.forEach(field => {
+      billingForm.invalidFields.forEach((field) => {
         billingForm.onFieldBlur(field)
       })
       shouldSubmit = false
@@ -187,8 +201,8 @@ const ExtraData: React.VFC<Props> = ({
   const mustShowDocumentField = cardType === 'new' && documentIsRequired
 
   return (
-    <div>
-      <span className="dib t-heading-6 mb5">
+    <div className={handles.extraDataContainer}>
+      <span className={`${handles.selectedPaymentLabel} dib t-heading-6 mb5`}>
         {intl.formatMessage(messages.selectedPaymentLabel)}
       </span>
 
@@ -203,14 +217,20 @@ const ExtraData: React.VFC<Props> = ({
         }
       />
 
-      <span className="dib mt5 t-body lh-copy">
+      <span
+        className={`${handles.creditCardExtraDataMessage} dib mt5 t-body lh-copy`}
+      >
         {intl.formatMessage(messages.creditCardExtraDataMessage)}
       </span>
 
       <form onSubmit={handleSubmit}>
         {mustShowDocumentField && (
-          <div className="mt6 flex items-center">
-            <div className="w-100 mw-100 mw5-ns">
+          <div
+            className={`${handles.documentFieldSectionContainer} mt6 flex items-center`}
+          >
+            <div
+              className={`${handles.documentFieldContainer} w-100 mw-100 mw5-ns`}
+            >
               <DocumentField
                 label={intl.formatMessage(messages.documentLabel)}
                 documentType="cpf"
@@ -226,7 +246,7 @@ const ExtraData: React.VFC<Props> = ({
           </div>
         )}
 
-        <div className="mt6">
+        <div className={`${handles.billingAddressSectionContainer} mt6`}>
           <Dropdown
             label={intl.formatMessage(messages.billingAddressLabel)}
             options={billingAddressesOptions}
@@ -240,15 +260,15 @@ const ExtraData: React.VFC<Props> = ({
           />
 
           {selectedBillingAddressId === NEW_ADDRESS_VALUE && (
-            <div className="mt6">
+            <div className={`${handles.billingAddressFormContainer} mt6`}>
               <BillingAddressForm form={billingForm} />
             </div>
           )}
         </div>
 
-        <div className="mt7">
+        <div className={`${handles.reviewPurchaseButtonContainer} mt7`}>
           <Button size="large" block type="submit">
-            <span className="f5">
+            <span className={`${handles.reviewPurchaseButtonLabel} f5`}>
               {intl.formatMessage(messages.reviewPurchaseLabel)}
             </span>
           </Button>

--- a/react/package.json
+++ b/react/package.json
@@ -30,6 +30,8 @@
     "vtex.checkout-components": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-components@0.5.1/public/@types/vtex.checkout-components",
     "vtex.checkout-container": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-container@0.7.0/public/@types/vtex.checkout-container",
     "vtex.checkout-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-graphql@0.56.1/public/@types/vtex.checkout-graphql",
+    "vtex.checkout-shipping": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-shipping@0.6.6/public/@types/vtex.checkout-shipping",
+    "vtex.css-handles": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.css-handles@1.0.0/public/@types/vtex.css-handles",
     "vtex.document-field": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.document-field@0.1.1/public/@types/vtex.document-field",
     "vtex.formatted-price": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.formatted-price@0.4.0/public/@types/vtex.formatted-price",
     "vtex.order-manager": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-manager@0.9.0/public/@types/vtex.order-manager",

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -5386,6 +5386,14 @@ verror@1.10.0:
   version "0.56.1"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-graphql@0.56.1/public/@types/vtex.checkout-graphql#c1153ec5faf232f92abfe495f867019bfb7d510f"
 
+"vtex.checkout-shipping@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-shipping@0.6.6/public/@types/vtex.checkout-shipping":
+  version "0.6.6"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-shipping@0.6.6/public/@types/vtex.checkout-shipping#c71713765bf87c50bb64016738450171a6e91c12"
+
+"vtex.css-handles@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.css-handles@1.0.0/public/@types/vtex.css-handles":
+  version "1.0.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.css-handles@1.0.0/public/@types/vtex.css-handles#336b23ef3a9bcb2b809529ba736783acd405d081"
+
 "vtex.document-field@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.document-field@0.1.1/public/@types/vtex.document-field":
   version "0.1.1"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.document-field@0.1.1/public/@types/vtex.document-field#222a1052f966f79209ee8ec998fcd43ecd7fbcce"


### PR DESCRIPTION
#### What problem is this solving?

**OBS:** _This is a copy of https://github.com/vtex-apps/checkout-payment/pull/25, which I had to close because it was unsynchronized with the branch it should represent._

Adds customization possibilities to the **Extra Data** and **Payment List** sections

#### How should this be manually tested?

1. Visit this linked [workspace](https://artur--extensions.myvtex.com/vtex-sms-provider/p);
2. Click `Get App`;
3. Provide a store name, e.g., `storecomponents`;
4. When the login flow is done, you'll be able to choose one of the payment options;
5. Open your browser's Developer Tools. If you inspect whichever payment option button, it will contain a CSS handle class;
6. Choose Credit Card;
7. Notice that when extra data information is required, no billing address inputs are displayed.

#### Checklist/Reminders

- [x] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] Linked this PR to a Jira story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

Payment Options:

![image](https://user-images.githubusercontent.com/3827456/111166182-a07f4180-857e-11eb-86a4-d6c9c0b97c4c.png)

(Extra Data) Before:

![image](https://user-images.githubusercontent.com/3827456/108277321-016e5200-7158-11eb-8c67-29fde3faf9cd.png)

(Extra Data) After:

![image](https://user-images.githubusercontent.com/3827456/108277445-2a8ee280-7158-11eb-8585-8dc6d9bf1ff2.png)

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and an overall reduction of technical debt -->

#### Notes

In this example workspace, the following customization is active:

`vtex.checkout-step-group.css`

```css
.billingAddressSectionContainer {
  display: none;
}
```
